### PR TITLE
Add AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: 3.0.1.{build}
+
+platform:
+    - x86
+
+skip_commits:
+  message: /\[skip ci\]/
+
+shallow_clone: true
+
+install:
+    - choco -y install autoit.commandline
+
+build_script:
+    - del .gitattributes
+    - del .gitignore
+    - del appveyor.yml
+    - aut2exe /in "CGB Bot.au3"
+    - 7z a "CGBv3.0.1 build %APPVEYOR_BUILD_NUMBER%.zip" .\*
+
+artifacts:
+  - path: CGBv3.0.1 build *.zip


### PR DESCRIPTION
Hi,

As said earlier, here is the conf file for the CI. Register an account on AppVeyor and enable this repo, and it will automatically build a .zip (containing the .exe) on each commit. If you don't want one commit to be built (for example if editing a README, no need to build for that), prepend `[skip ci]` to the commit message.

Latest downloadable build will be available at https://ci.appveyor.com/project/Blaze5145/cgb-unofficial-v3/build/artifacts, you can add this to the README so that people can download without the need to deal with AutoIt.
